### PR TITLE
Fixed builder input_tensor error.

### DIFF
--- a/classification_models/senet/builder.py
+++ b/classification_models/senet/builder.py
@@ -73,7 +73,7 @@ def build_senet(
         if not K.is_keras_tensor(input_tensor):
             input = kl.Input(tensor=input_tensor, shape=input_shape)
         else:
-            input = kl.input_tensor
+            input = input_tensor
 
     x = input
 


### PR DESCRIPTION
input_tensor was wrongly passed as kl.input_tensor causing keras to throw no input_tensor in keras.layers error.